### PR TITLE
Update deadline job submission to correctly validate files

### DIFF
--- a/pyblish_bumpybox/plugins/deadline/collect_nuke_parameters.py
+++ b/pyblish_bumpybox/plugins/deadline/collect_nuke_parameters.py
@@ -39,15 +39,32 @@ class BumpyboxDeadlineCollectNukeParameters(pyblish.api.ContextPlugin):
                 msg = "No existing \"deadlinePriority\" parameter."
                 self.log.info(msg)
 
-            # Gettng pool
+            # Getting pool
             if "deadlinePool" in node.knobs():
                 value = node["deadlinePool"].getValue()
                 instance.data["deadlinePool"] = value
             else:
-                msg = "No existing \"deadlinePool\" parameter."
+                msg = "No existing \"deadlinePool\" parameter, defaulting to 'medium'"
+                instance.data["deadlinePool"] = "medium"
                 self.log.info(msg)
 
-            # Gettng concurrent tasks
+            # Getting group
+            if "deadlineGroup" in node.knobs():
+                value = node["deadlineGroup"].getValue()
+                instance.data["deadlineGroup"] = value
+            else:
+                msg = "No existing \"deadlineGroup\" parameter"
+                self.log.info(msg)
+
+            # Getting limits
+            if "deadlineLimits" in node.knobs():
+                value = node["deadlineLimits"].getValue()
+                instance.data["deadlineLimits"] = value
+            else:
+                msg = "No existing \"deadlineLimits\" parameter."
+                self.log.info(msg)
+
+            # Getting concurrent tasks
             if "deadlineConcurrentTasks" in node.knobs():
                 value = node["deadlineConcurrentTasks"].getValue()
                 instance.data["deadlineConcurrentTasks"] = value

--- a/pyblish_bumpybox/plugins/deadline/extract_nuke.py
+++ b/pyblish_bumpybox/plugins/deadline/extract_nuke.py
@@ -17,7 +17,6 @@ class BumpyboxDeadlineExtractNuke(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        node = instance[0]
         collection = instance.data["collection"]
 
         data = instance.data.get("deadlineData", {"job": {}, "plugin": {}})
@@ -26,9 +25,11 @@ class BumpyboxDeadlineExtractNuke(pyblish.api.InstancePlugin):
         data["job"]["Plugin"] = "Nuke"
         data["job"]["Priority"] = int(instance.data["deadlinePriority"])
         data["job"]["Pool"] = instance.data["deadlinePool"]
+        data["job"]["Group"] = instance.data["deadlineGroup"]
         data["job"]["ConcurrentTasks"] = int(
             instance.data["deadlineConcurrentTasks"]
         )
+        data["job"]["LimitGroups"] = instance.data["deadlineLimits"]
 
         # Replace houdini frame padding with Deadline padding
         fmt = "{head}" + "#" * collection.padding + "{tail}"

--- a/pyblish_bumpybox/plugins/deadline/validate_nuke_parameters.py
+++ b/pyblish_bumpybox/plugins/deadline/validate_nuke_parameters.py
@@ -37,6 +37,14 @@ class BumpyboxDeadlineRepairParameters(pyblish.api.Action):
             node.addKnob(knob)
 
             knob = nuke.String_Knob("deadlinePool", "Pool")
+            knob.setValue("medium")
+            node.addKnob(knob)
+
+            knob = nuke.String_Knob("deadlineGroup", "Group")
+            knob.setValue("nuke")
+            node.addKnob(knob)
+
+            knob = nuke.String_Knob("deadlineLimits", "Limits")
             node.addKnob(knob)
 
             knob = nuke.Int_Knob(
@@ -65,8 +73,14 @@ class BumpyboxDeadlineValidateNukeParameters(pyblish.api.InstancePlugin):
         msg = "Could not find Priority on node \"{0}\"".format(node)
         assert "deadlinePriority" in instance.data, msg
 
+        msg = "Could not find Group on node \"{0}\"".format(node)
+        assert "deadlineGroup" in instance.data, msg
+
         msg = "Could not find Pool on node \"{0}\"".format(node)
         assert "deadlinePool" in instance.data, msg
 
         msg = "Could not find Concurrent Tasks on node \"{0}\"".format(node)
         assert "deadlineConcurrentTasks" in instance.data, msg
+
+        msg = "Could not find Limits on node \"{0}\"".format(node)
+        assert "deadlineLimits" in instance.data, msg

--- a/pyblish_bumpybox/plugins/nuke/collect_writes.py
+++ b/pyblish_bumpybox/plugins/nuke/collect_writes.py
@@ -61,12 +61,9 @@ class BumpyboxNukeCollectWrites(pyblish.api.ContextPlugin):
             # Add collection
             collection = None
             try:
-                path = os.path.abspath(
-                    node["file"].getValue().replace(
-                        "[python {nuke.script_directory()}]",
-                        os.path.dirname(context.data["currentFile"])
-                    )
-                )
+                path = ""
+                if nuke.filename(node):
+                    path = nuke.filename(node)
                 path += " [{0}-{1}]".format(start_frame, end_frame)
                 collection = clique.parse(path)
             except Exception as e:

--- a/pyblish_bumpybox/plugins/nuke/validate_write_file.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_write_file.py
@@ -1,6 +1,7 @@
 import os
 
 import pyblish.api
+import nuke
 
 
 class BumpyboxNukeRepairWriteFile(pyblish.api.Action):
@@ -62,8 +63,7 @@ class BumpyboxNukeValidateWriteFile(pyblish.api.InstancePlugin):
         assert os.path.exists(path), msg
 
     def get_expected_value(self, instance):
-
-        expected = "[python {nuke.script_directory()}]/workspace/"
+        expected = nuke.script_directory() + "/workspace/"
 
         current = instance[0]["file"].getEvaluatedValue()
         current_file = instance.context.data["currentFile"]


### PR DESCRIPTION
Use of the script_directory() code in the path was causing nodes to return the local node directory (C:\) instead of the mapped network drive.

Remove replacement of interpreted python code and instead just retrieve the path on validation.

Additionally, add the limit and group options to nuke knobs and set them to appropriate defaults.

