### PR TITLE
Always create list from path

### DIFF
--- a/pyblish_bumpybox/plugins/hiero/extract_ftrack_shot.py
+++ b/pyblish_bumpybox/plugins/hiero/extract_ftrack_shot.py
@@ -67,12 +67,14 @@ class BumpyboxHieroExtractFtrackShot(pyblish.api.InstancePlugin):
 
         # Setup parent.
         parent = parents[0]
+
+        copy_path = list(path)
+
         if "--" in item.name():
             name_split = item.name().split("--")
 
             if len(name_split) == 2:
                 try:
-                    copy_path = list(path)
                     copy_path.append(name_split[0])
                     parent = ftrack.getSequence(copy_path)
                 except:
@@ -81,7 +83,6 @@ class BumpyboxHieroExtractFtrackShot(pyblish.api.InstancePlugin):
 
             if len(name_split) == 3:
                 try:
-                    copy_path = list(path)
                     copy_path.append(name_split[0])
                     parent = ftrack.getSequence(copy_path)
                 except:


### PR DESCRIPTION
Correct path extraction to always covert the string path to a list.

Previously because copy_path did not always exist, this caused Hiero shot creation to fail if shots were created without "--" in the title, i.e they were at the root of the project.