### PR TITLE
Update maya/nuke deadline defaults

### DIFF
--- a/pyblish_bumpybox/plugins/deadline/collect_maya_parameters.py
+++ b/pyblish_bumpybox/plugins/deadline/collect_maya_parameters.py
@@ -23,7 +23,7 @@ class BumpyboxDeadlineCollectMayaParameters(pyblish.api.ContextPlugin):
 
             node = instance[0]
 
-            # Gettng chunk size
+            # Getting chunk size
             try:
                 value = node.deadlineChunkSize.get()
                 instance.data["deadlineChunkSize"] = value
@@ -31,7 +31,7 @@ class BumpyboxDeadlineCollectMayaParameters(pyblish.api.ContextPlugin):
                 msg = "No existing \"deadlineChunkSize\" parameter."
                 self.log.warning(msg)
 
-            # Gettng priority
+            # Getting priority
             try:
                 value = node.deadlinePriority.get()
                 instance.data["deadlinePriority"] = value
@@ -39,7 +39,7 @@ class BumpyboxDeadlineCollectMayaParameters(pyblish.api.ContextPlugin):
                 msg = "No existing \"deadlinePriority\" parameter."
                 self.log.warning(msg)
 
-            # Gettng pool
+            # Getting pool
             try:
                 value = node.deadlinePool.get()
                 instance.data["deadlinePool"] = value
@@ -47,10 +47,26 @@ class BumpyboxDeadlineCollectMayaParameters(pyblish.api.ContextPlugin):
                 msg = "No existing \"deadlinePool\" parameter."
                 self.log.warning(msg)
 
-            # Gettng concurrent tasks
+            # Getting concurrent tasks
             try:
                 value = node.deadlineConcurrentTasks.get()
                 instance.data["deadlineConcurrentTasks"] = value
             except:
                 msg = "No existing \"deadlineConcurrentTasks\" parameter."
+                self.log.warning(msg)
+
+            # Getting groups
+            try:
+                value = node.deadlineGroup.get()
+                instance.data["deadlineGroup"] = value
+            except:
+                msg = "No existing \"deadlineGroup\" parameter."
+                self.log.warning(msg)
+
+            # Getting limits
+            try:
+                value = node.deadlineLimits.get()
+                instance.data["deadlineLimits"] = value
+            except:
+                msg = "No existing \"deadlineLimits\" parameter."
                 self.log.warning(msg)

--- a/pyblish_bumpybox/plugins/deadline/extract_maya.py
+++ b/pyblish_bumpybox/plugins/deadline/extract_maya.py
@@ -33,6 +33,8 @@ class BumpyboxDeadlineExtractMaya(pyblish.api.InstancePlugin):
         data["job"]["Pool"] = instance.data["deadlinePool"]
         value = instance.data["deadlineConcurrentTasks"]
         data["job"]["ConcurrentTasks"] = value
+        data["job"]["LimitGroups"] = instance.data["deadlineLimits"]
+        data["job"]["Group"] = instance.data["deadlineGroup"]
 
         # Frame range
         render_globals = pymel.core.PyNode("defaultRenderGlobals")

--- a/pyblish_bumpybox/plugins/deadline/validate_maya_parameters.py
+++ b/pyblish_bumpybox/plugins/deadline/validate_maya_parameters.py
@@ -30,7 +30,7 @@ class BumpyboxDeadlineRepairParameters(pyblish.api.Action):
             if not hasattr(node, "deadlineChunkSize"):
                 pymel.core.addAttr(node,
                                    longName="deadlineChunkSize",
-                                   defaultValue=1,
+                                   defaultValue=10,
                                    attributeType="long")
                 attr = pymel.core.Attribute(node.name() + ".deadlineChunkSize")
                 pymel.core.setAttr(attr, channelBox=True)
@@ -48,7 +48,7 @@ class BumpyboxDeadlineRepairParameters(pyblish.api.Action):
                                    longName="deadlinePool",
                                    dataType="string")
                 attr = pymel.core.Attribute(node.name() + ".deadlinePool")
-                pymel.core.setAttr(attr, channelBox=True)
+                pymel.core.setAttr(attr, "medium", channelBox=True)
 
             if not hasattr(node, "deadlineConcurrentTasks"):
                 pymel.core.addAttr(node,
@@ -59,6 +59,26 @@ class BumpyboxDeadlineRepairParameters(pyblish.api.Action):
                     node.name() + ".deadlineConcurrentTasks"
                 )
                 pymel.core.setAttr(attr, channelBox=True)
+
+            if not hasattr(node, "deadlineGroup"):
+                pymel.core.addAttr(node,
+                                   longName="deadlineGroup",
+                                   dataType="string")
+                attr = pymel.core.Attribute(
+                    node.name() + ".deadlineGroup"
+                )
+                pymel.core.setAttr(attr, "maya", channelBox=True)
+
+            if not hasattr(node, "deadlineLimits"):
+                current_renderer = pymel.core.getAttr("defaultRenderGlobals.currentRenderer")
+
+                pymel.core.addAttr(node,
+                                   longName="deadlineLimits",
+                                   dataType="string")
+                attr = pymel.core.Attribute(
+                    node.name() + ".deadlineLimits"
+                )
+                pymel.core.setAttr(attr, current_renderer, channelBox=True)
 
 
 class BumpyboxDeadlineValidateMayaParameters(pyblish.api.InstancePlugin):
@@ -85,3 +105,9 @@ class BumpyboxDeadlineValidateMayaParameters(pyblish.api.InstancePlugin):
 
         msg = "Could not find Concurrent Tasks on node \"{0}\"".format(node)
         assert "deadlineConcurrentTasks" in instance.data, msg
+
+        msg = "Could not find Group on node \"{0}\"".format(node)
+        assert "deadlineGroup" in instance.data, msg
+
+        msg = "Could not find Limit Groups on node \"{0}\"".format(node)
+        assert "deadlineLimits" in instance.data, msg

--- a/pyblish_bumpybox/plugins/deadline/validate_nuke_parameters.py
+++ b/pyblish_bumpybox/plugins/deadline/validate_nuke_parameters.py
@@ -29,7 +29,7 @@ class BumpyboxDeadlineRepairParameters(pyblish.api.Action):
             node.addKnob(nuke.Tab_Knob("Deadline"))
 
             knob = nuke.Int_Knob("deadlineChunkSize", "Chunk Size")
-            knob.setValue(1)
+            knob.setValue(10)
             node.addKnob(knob)
 
             knob = nuke.Int_Knob("deadlinePriority", "Priority")


### PR DESCRIPTION
Maya defaults for deadline submission do not currently use redshift as the renderer, or set the group.

Make changes to use the default renderer from mayas render settings as the limit group and set the group to maya.

For both maya and nuke, default the chunksize to 10.