### PR TITLE
Set movies to use 'main' component name

### DIFF
--- a/pyblish_bumpybox/plugins/extract_movie.py
+++ b/pyblish_bumpybox/plugins/extract_movie.py
@@ -74,13 +74,7 @@ class BumpyboxExtractMovie(pyblish.api.InstancePlugin):
 
         self.log.debug(output)
 
-        output_collection = clique.Collection(
-            head=collection.format("{head}"),
-            padding=4,
-            tail=".mov"
-        )
-        output_collection.add(output_file)
-
+        # The component name *must* be the default playable component for movie
         components = instance.data.get("ftrackComponentsList", [])
         components.append({
             "assettype_data": {"short": "mov"},
@@ -88,11 +82,9 @@ class BumpyboxExtractMovie(pyblish.api.InstancePlugin):
                 "version": instance.context.data["version"]
             },
             "component_data": {
-                "name": instance.data.get(
-                    "component_name", instance.data["name"]
-                ),
+                "name": "main",
             },
-            "component_path": output_collection.format(),
+            "component_path": output_file,
             "component_overwrite": True,
         })
         instance.data["ftrackComponentsList"] = components

--- a/pyblish_bumpybox/plugins/nuke/validate_write_file.py
+++ b/pyblish_bumpybox/plugins/nuke/validate_write_file.py
@@ -66,8 +66,8 @@ class BumpyboxNukeValidateWriteFile(pyblish.api.InstancePlugin):
         padded_version = str(instance.context.data["version"]).zfill(3)
 
         expected = nuke.script_directory() + "/workspace/"
-        expected += instance[0].name() + "/"
         expected += "v" + padded_version + "/"
+        expected += instance[0].name() + "/"
         expected += os.path.splitext(os.path.basename(nuke.scriptName()))[0]
 
         current = nuke.filename(instance[0])


### PR DESCRIPTION
By default, movies adopt the name of the component being created and are set as sequence components. This means that they are unplayable via RV as it defaults to the ftracks playable component name for a component, currently set to "main" for Bait and assumes it is a filecomponent being opened.

This change correct the movies created in ftrack to use the "main" component name and a filecomponent, so they are playable via RV.