### PR TITLE
Allow File Component Cleanup

### DIFF
--- a/pyblish_bumpybox/plugins/ftrack/integrate_ftrack_clean_up.py
+++ b/pyblish_bumpybox/plugins/ftrack/integrate_ftrack_clean_up.py
@@ -19,8 +19,15 @@ class BumpyboxIntegrateFtrackCleanUp(pyblish.api.InstancePlugin):
 
         for data in instance.data.get("ftrackComponentsList", []):
             path = data["component_path"]
+
+            # Iterates all published components and removes those that
+            # are within collection
             if "component" in data and "workspace" in path:
-                collection = clique.parse(path)
-                for f in collection:
-                    os.remove(f)
-                    self.log.info("Deleted: \"{0}\"".format(f))
+                if os.path.exists(path):
+                    # This is a file component which needs removing
+                    os.remove(path)
+                else:
+                    collection = clique.parse(path)
+                    for f in collection:
+                        os.remove(f)
+                        self.log.info("Deleted: \"{0}\"".format(f))


### PR DESCRIPTION
Currently cleanup assumes all published components are sequence components.

This PR checks whether the file exists on the system (a file component) and removes it so, before interpreting as a sequence component.