### PR TITLE
Connect lookdev vis to alembic cache vis

### DIFF
--- a/pyblish_bumpybox/environment_variables/pythonpath/ftrack_assets.py
+++ b/pyblish_bumpybox/environment_variables/pythonpath/ftrack_assets.py
@@ -70,9 +70,9 @@ class CacheAsset(GenericAsset):
                 dst_node = dst_map[dst_name]
 
                 if dst_node.nodeType() == "transform":
-                    for transform in ["translate", "rotate", "scale", "visibility"]:
-                        src_attr = pm.PyNode(src_node.name() + "." + transform)
-                        dst_attr = pm.PyNode(dst_node.name() + "." + transform)
+                    for attribute in ["translate", "rotate", "scale", "visibility"]:
+                        src_attr = pm.PyNode(src_node.name() + "." + attribute)
+                        dst_attr = pm.PyNode(dst_node.name() + "." + attribute)
                         src_attr >> dst_attr
 
                 # Connect animation and worldspace placement with blendshape

--- a/pyblish_bumpybox/environment_variables/pythonpath/ftrack_assets.py
+++ b/pyblish_bumpybox/environment_variables/pythonpath/ftrack_assets.py
@@ -70,7 +70,7 @@ class CacheAsset(GenericAsset):
                 dst_node = dst_map[dst_name]
 
                 if dst_node.nodeType() == "transform":
-                    for transform in ["translate", "rotate", "scale"]:
+                    for transform in ["translate", "rotate", "scale", "visibility"]:
                         src_attr = pm.PyNode(src_node.name() + "." + transform)
                         dst_attr = pm.PyNode(dst_node.name() + "." + transform)
                         src_attr >> dst_attr


### PR DESCRIPTION
Although alembic caches the visibility of scene objects, these are not connected on import through ftracks importer. 

Add the visibility to the list of attributes to be copied from the cache.