### PR TITLE
Add remote alembic creation

### DIFF
--- a/pyblish_bumpybox/plugins/deadline/extract_maya.py
+++ b/pyblish_bumpybox/plugins/deadline/extract_maya.py
@@ -1,4 +1,3 @@
-import math
 import os
 
 import pymel.core
@@ -19,6 +18,8 @@ class BumpyboxDeadlineExtractMaya(pyblish.api.InstancePlugin):
     hosts = ["maya"]
 
     def process(self, instance):
+        if "alembic" in instance.data["families"]:
+            return
 
         collection = instance.data["collection"]
 

--- a/pyblish_bumpybox/plugins/maya/extract_alembic.py
+++ b/pyblish_bumpybox/plugins/maya/extract_alembic.py
@@ -14,6 +14,8 @@ class BumpyboxMayaExtractAlembic(pyblish.api.InstancePlugin):
     hosts = ["maya"]
 
     def process(self, instance):
+        if "remote" in instance.data["families"]:
+            return
 
         # Validate whether we can strip namespaces.
         nodesString = ""

--- a/pyblish_bumpybox/plugins/maya/extract_remote_alembic.py
+++ b/pyblish_bumpybox/plugins/maya/extract_remote_alembic.py
@@ -52,10 +52,23 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
         deadline_arguments["job"]["Plugin"] = "MayaBatch"
         deadline_arguments['job']['OutputFilename0'] = output_path
 
-        deadline_arguments['plugin']['AlembicSelection'] = instance[0][0].name()
+        selected_nodes = []
+        root_nodes = []
+        strip_namespaces = True
+
+        for item in instance[0]:
+            selected_nodes.append(item.name())
+            root_node = item.name().split(":")[-1]
+            if root_node not in selected_nodes:
+                root_nodes.append(root_node)
+            else:
+                strip_namespaces = False
+
+        deadline_arguments['plugin']['AlembicSelection'] = ",".join(selected_nodes)
         deadline_arguments['plugin']['OutputFilePath'] = output_dir
         deadline_arguments['plugin']['OutputFile'] = output_file
 
+        deadline_arguments['plugin']['StripNamespaces'] = strip_namespaces
         deadline_arguments['plugin']['Camera'] = ""
         deadline_arguments['plugin']['Camera0'] = ""
         deadline_arguments['plugin']['SceneFile'] = instance.context.data['currentFile']

--- a/pyblish_bumpybox/plugins/maya/extract_remote_alembic.py
+++ b/pyblish_bumpybox/plugins/maya/extract_remote_alembic.py
@@ -1,0 +1,74 @@
+import os
+
+import pymel
+import pyblish.api
+import maya.cmds as cmds
+
+from bait.paths import get_cache_output_path
+from bait.deadline import format_frames, get_render_settings, get_deadline_data
+from bait.ftrack.query_runner import QueryRunner
+
+
+class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
+    """ Extracts alembic files using deadline. """
+
+    order = pyblish.api.ExtractorOrder + 0.1
+    families = ["alembic"]
+    optional = True
+    label = "Remote Alembic"
+    hosts = ["maya"]
+
+    def process(self, instance):
+        if "local" in instance.data["families"]:
+            return
+
+        # Generate export command.
+        frame_start = int(pymel.core.playbackOptions(q=True, min=True))
+        frame_end = int(pymel.core.playbackOptions(q=True, max=True))
+
+        render_settings = get_render_settings("alembic")
+
+        deadline_arguments = instance.data.get(
+            "deadlineData", {"job": {}, "plugin": {}}
+        )
+        deadline_arguments['job']['Frames'] = format_frames(frame_start, frame_end)
+
+        runner = QueryRunner()
+        default_pool = runner.get_project_department(instance.context.data["ftrackData"]["Project"]["id"])
+        deadline_arguments["job"]["Pool"] = default_pool
+        runner.close_session()
+
+        deadline_arguments['plugin']['WriteVisibility'] = True
+
+        component_name = instance.data["name"]
+        version = instance.context.data["version"]
+        task_id = instance.context.data['ftrackTask']['id']
+
+        output_path = get_cache_output_path(task_id, component_name, version, ".0001.abc")
+
+        output_dir = os.path.dirname(output_path)
+        output_file = os.path.basename(output_path)
+
+        deadline_arguments["job"]["Plugin"] = "MayaBatch"
+        deadline_arguments['job']['OutputFilename0'] = output_path
+
+        deadline_arguments['plugin']['AlembicSelection'] = instance[0][0].name()
+        deadline_arguments['plugin']['OutputFilePath'] = output_dir
+        deadline_arguments['plugin']['OutputFile'] = output_file
+
+        deadline_arguments['plugin']['Camera'] = ""
+        deadline_arguments['plugin']['Camera0'] = ""
+        deadline_arguments['plugin']['SceneFile'] = instance.context.data['currentFile']
+
+        for index, camera in enumerate(cmds.listCameras()):
+            deadline_arguments['plugin']['Camera{}'.format(index + 1)] = camera
+
+        self.log.info("Output Dir: {}".format(output_dir))
+        self.log.info("Output File: {}".format(output_file))
+        self.log.info("Item names: {}".format(instance[0]))
+
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # Call deadline
+        instance.data['deadlineData'] = get_deadline_data(render_settings, deadline_arguments)

--- a/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
+++ b/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
@@ -21,18 +21,6 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
         if "local" in instance.data["families"]:
             return
 
-        # Validate whether we can strip namespaces.
-        nodes_string = ""
-        strip_namespaces = True
-        root_names = []
-
-        for member in instance[0]:
-            nodes_string += "-root %s " % member.name()
-            if member.name().split(":")[-1] not in root_names:
-                root_names.append(member.name().split(":")[-1])
-            else:
-                strip_namespaces = False
-
         # Generate export command.
         frame_start = int(pymel.core.playbackOptions(q=True, min=True))
         frame_end = int(pymel.core.playbackOptions(q=True, max=True))
@@ -44,13 +32,7 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
         )
         deadline_arguments['job']['frames'] = format_frames(frame_start, frame_end)
 
-        if not strip_namespaces:
-            msg = "Can't strip namespaces, because of conflicting root names."
-            msg += " Nodes will be renamed."
-            self.log.warning(msg)
-
-        deadline_arguments['plugin']['StripNamespaces'] = strip_namespaces
-        deadline_arguments['plugin']['WriteVisibility'] = nodes_string
+        deadline_arguments['plugin']['WriteVisibility'] = True
 
         component_name = instance.data["name"]
         version = instance.context.data["version"]
@@ -64,7 +46,7 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
         deadline_arguments["job"]["Plugin"] = "MayaBatch"
         deadline_arguments['job']['OutputFilename0'] = output_path
 
-        deadline_arguments['plugin']['AlembicSelection'] = instance[0]
+        deadline_arguments['plugin']['AlembicSelection'] = instance[0][0].name()
         deadline_arguments['plugin']['OutputFilePath'] = output_dir
         deadline_arguments['plugin']['OutputFile'] = output_file
 

--- a/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
+++ b/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
@@ -1,0 +1,70 @@
+import os
+
+import pymel
+import pyblish.api
+
+from bait.paths import get_output_path
+from bait.deadline import format_frames, get_render_settings, get_deadline_data
+
+
+class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
+    """ Extracts alembic files using deadline. """
+
+    order = pyblish.api.ExtractorOrder
+    families = ["alembic"]
+    optional = True
+    label = "Remote Alembic"
+    hosts = ["maya"]
+
+    def process(self, instance):
+
+        # Validate whether we can strip namespaces.
+        nodes_string = ""
+        strip_namespaces = True
+        root_names = []
+
+        for member in instance[0]:
+            nodes_string += "-root %s " % member.name()
+            if member.name().split(":")[-1] not in root_names:
+                root_names.append(member.name().split(":")[-1])
+            else:
+                strip_namespaces = False
+
+        # Generate export command.
+        frame_start = int(pymel.core.playbackOptions(q=True, min=True))
+        frame_end = int(pymel.core.playbackOptions(q=True, max=True))
+
+        render_settings = get_render_settings("alembic")
+
+        deadline_arguments = {'job': {}, 'plugin': {}}
+        deadline_arguments['job']['frames'] = format_frames(frame_start, frame_end)
+
+        if not strip_namespaces:
+            msg = "Can't strip namespaces, because of conflicting root names."
+            msg += " Nodes will be renamed."
+            self.log.warning(msg)
+
+        deadline_arguments['plugin']['StripNamespaces'] = strip_namespaces
+        deadline_arguments['plugin']['WriteVisibility'] = nodes_string
+
+        component_name = instance.data["name"]
+        version = instance.context.data["version"]
+        task_id = instance.context.data['ftrackTask']['id']
+
+        output_path = get_output_path(task_id, component_name, version, ".abc")
+
+        output_dir = os.path.dirname(output_path)
+        output_file = os.path.basename(output_path)
+
+        deadline_arguments['plugin']['OutputFilePath'] = output_dir.replace("\\", "/")
+        deadline_arguments['plugin']['OutputFile'] = output_file
+
+        self.log.info("Output Dir: {}".format(output_dir))
+        self.log.info("Output File: {}".format(output_file))
+
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # Call deadline
+        instance.data['families'] += ['deadline']
+        instance.data['deadlineData'] = get_deadline_data(render_settings, deadline_arguments)

--- a/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
+++ b/pyblish_bumpybox/plugins_default_env/maya/extract_remote_alembic.py
@@ -2,21 +2,24 @@ import os
 
 import pymel
 import pyblish.api
+import maya.cmds as cmds
 
-from bait.paths import get_output_path
+from bait.paths import get_cache_output_path
 from bait.deadline import format_frames, get_render_settings, get_deadline_data
 
 
 class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
     """ Extracts alembic files using deadline. """
 
-    order = pyblish.api.ExtractorOrder
+    order = pyblish.api.ExtractorOrder + 0.1
     families = ["alembic"]
     optional = True
     label = "Remote Alembic"
     hosts = ["maya"]
 
     def process(self, instance):
+        if "local" in instance.data["families"]:
+            return
 
         # Validate whether we can strip namespaces.
         nodes_string = ""
@@ -36,7 +39,9 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
 
         render_settings = get_render_settings("alembic")
 
-        deadline_arguments = {'job': {}, 'plugin': {}}
+        deadline_arguments = instance.data.get(
+            "deadlineData", {"job": {}, "plugin": {}}
+        )
         deadline_arguments['job']['frames'] = format_frames(frame_start, frame_end)
 
         if not strip_namespaces:
@@ -51,20 +56,31 @@ class MayaExtractRemoteAlembic(pyblish.api.InstancePlugin):
         version = instance.context.data["version"]
         task_id = instance.context.data['ftrackTask']['id']
 
-        output_path = get_output_path(task_id, component_name, version, ".abc")
+        output_path = get_cache_output_path(task_id, component_name, version, ".abc")
 
         output_dir = os.path.dirname(output_path)
         output_file = os.path.basename(output_path)
 
-        deadline_arguments['plugin']['OutputFilePath'] = output_dir.replace("\\", "/")
+        deadline_arguments["job"]["Plugin"] = "MayaBatch"
+        deadline_arguments['job']['OutputFilename0'] = output_path
+
+        deadline_arguments['plugin']['AlembicSelection'] = instance[0]
+        deadline_arguments['plugin']['OutputFilePath'] = output_dir
         deadline_arguments['plugin']['OutputFile'] = output_file
+
+        deadline_arguments['plugin']['Camera'] = ""
+        deadline_arguments['plugin']['Camera0'] = ""
+        deadline_arguments['plugin']['SceneFile'] = instance.context.data['currentFile']
+
+        for index, camera in enumerate(cmds.listCameras()):
+            deadline_arguments['plugin']['Camera{}'.format(index + 1)] = camera
 
         self.log.info("Output Dir: {}".format(output_dir))
         self.log.info("Output File: {}".format(output_file))
+        self.log.info("Item names: {}".format(instance[0]))
 
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 
         # Call deadline
-        instance.data['families'] += ['deadline']
         instance.data['deadlineData'] = get_deadline_data(render_settings, deadline_arguments)


### PR DESCRIPTION
**Motivation**

Add a rule for extracting alembics remotely via deadline. This is desirable to allow long running alembics to be quickly sent off to deadline rather than lock an artists machine for a given amount of time.

**Changes**

Add a publish rule for create remote alembics which uses a remote set to identify them. Ignore the rule when local alembic is executed.